### PR TITLE
Add missing files from override

### DIFF
--- a/config/initializers/decidim_overrides.rb
+++ b/config/initializers/decidim_overrides.rb
@@ -4,4 +4,5 @@ Rails.application.config.to_prepare do
   Decidim::Amendable.include(Decidim::Overrides::AmendableOverride)
   Decidim::Amendment.include(Decidim::AmendmentOverride)
   Decidim::UpdateAccount.include(Decidim::UpdateAccountOverride)
+  Decidim::DiffCell.include(Decidim::DiffCellOverride)
 end

--- a/spec/lib/overrides_spec.rb
+++ b/spec/lib/overrides_spec.rb
@@ -17,7 +17,9 @@ checksums = [
       # models
       "/app/models/decidim/amendment.rb" => "a49c2328f9f612150ce15fd627066996",
       # commands
-      "/app/commands/decidim/update_account.rb" => "d24090fdd9358c38e6e15c4607a78e18"
+      "/app/commands/decidim/update_account.rb" => "d24090fdd9358c38e6e15c4607a78e18",
+      # cells
+      "/app/cells/decidim/diff_cell.rb" => "30c499b4b3eed47aae0cf69318842533"
     }
   },
   {


### PR DESCRIPTION
Missing override files from this commit for `decidim 0.29`: https://github.com/Platoniq/decidim-ub/commit/26259c960477c3a5ab2172ab9e3491e2b3655413